### PR TITLE
build: add utilities to conditionally perform an action and retrieve envs

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/DotenvUtils.kt
+++ b/buildSrc/src/main/kotlin/DotenvUtils.kt
@@ -1,0 +1,57 @@
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.process.ProcessForkOptions
+import java.io.File
+import kotlin.reflect.KClass
+
+object DotenvUtils {
+
+    val Project.dotenv: DotEnv?
+        get() = file(".env").takeIf { it.exists() }?.let { DotEnv.from(it) }
+
+    fun <T> Project.injectInto(vararg taskTypes: KClass<out T>) where T : Task, T : ProcessForkOptions =
+        ProcessForkOptionConfigurator(
+            taskTypes.flatMap { tasks.withType(it.java) }
+        )
+
+    class ProcessForkOptionConfigurator<T>(private val taskTypes: List<T>) where T : Task, T : ProcessForkOptions {
+        infix fun environmentsFrom(dotenv: DotEnv) = taskTypes.forEach {
+            it.doFirst {
+                dotenv.variables().forEach { (key, value) -> it.environment(key, value) }
+            }
+        }
+    }
+
+    interface DotEnv {
+
+        /** The `*.env` file instance. */
+        val file: File
+
+        /** @return a map environment variables key-value pairs. */
+        fun variables(): Map<String, String>
+
+        companion object {
+            fun from(file: File): DotEnv = DotEnvImpl(file)
+        }
+    }
+
+    private class DotEnvImpl(override val file: File) : DotEnv {
+
+        init {
+            require(file.exists() && file.name.endsWith(EXTENSION_NAME)) {
+                "File $file does not exist or has wrong extension. Only `*$EXTENSION_NAME` files are supported."
+            }
+        }
+
+        override fun variables(): Map<String, String> = file
+            .readLines()
+            .filter { it.isNotBlank() && !it.startsWith(COMMENT_SYMBOL) }
+            .associate { it.split(KEY_VALUE_SEPARATOR).let { (key, value) -> key to value } }
+
+        private companion object {
+            const val EXTENSION_NAME = ".env"
+            const val COMMENT_SYMBOL = "#"
+            const val KEY_VALUE_SEPARATOR = "="
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/Utils.kt
+++ b/buildSrc/src/main/kotlin/Utils.kt
@@ -1,0 +1,35 @@
+import org.gradle.internal.cc.base.logger
+
+object Utils {
+
+    val inCI: Boolean
+        get() = System.getenv()["CI"].equals("true", ignoreCase = true)
+
+    val onLinux: Boolean
+        get() = os().contains("linux", ignoreCase = true)
+
+    val onMac: Boolean
+        get() = os().contains("mac", ignoreCase = true)
+
+    val onWindows: Boolean
+        get() = os().contains("windows", ignoreCase = true)
+
+    private fun os(): String = System.getProperty("os.name")
+
+    fun normally(todo: () -> Unit): Normally = Normally(todo)
+
+    class Normally(private val normallyBlock: () -> Unit) {
+        infix fun except(condition: () -> Boolean): Conditionally = Conditionally(normallyBlock, condition)
+    }
+
+    class Conditionally(private val normallyBlock: () -> Unit, private val condition: () -> Boolean) {
+        infix fun where(exceptionalBlock: () -> Unit): ConditionallyWithCause = with(condition()) {
+            if (this) exceptionalBlock() else normallyBlock()
+            ConditionallyWithCause(this)
+        }
+    }
+
+    class ConditionallyWithCause(private val condition: Boolean) {
+        infix fun cause(reason: String) = if (condition) logger.quiet(reason) else Unit
+    }
+}


### PR DESCRIPTION
This PR moves into the template the utility functions I used to load environment variables from .env files into gradle processes and a minimal dsl to conditionally perform configurations depending on a condition in the build.

Example of usages: 
- https://github.com/position-pal/notification-service/blob/18dd148ac56690ffa18cffd452e6748115060856/build.gradle.kts#L75
- https://github.com/position-pal/notification-service/blob/18dd148ac56690ffa18cffd452e6748115060856/storage/build.gradle.kts#L16