### PR TITLE
ci: fix `is_force_push_pr` parameter position, add `pr_title` and custom github token

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -12,11 +12,16 @@ jobs:
       contents: write
       pull-requests: write
       repository-projects: read
-      is_force_push_pr: true
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          # This is needed to ensure the action to push workflow updates in `.github/workflows/*.yml` files.
+          # See https://github.com/AndreasAugustin/actions-template-sync#troubleshooting for more details.
+          token: '${{ secrets.TEMPLATE_SYNC_PAT }}'
       - name: actions-template-sync
         uses: AndreasAugustin/actions-template-sync@978f21ac252565d7ed55b582533e2cdf9653f72f # v2
         with:
           source_repo_path: position-pal/scala-template
+          is_force_push_pr: true
+          pr_title: 'chore: upstream template synchronization'

--- a/.templatesyncignore
+++ b/.templatesyncignore
@@ -1,4 +1,4 @@
 README.md
 CHANGELOG.md
 
-./core/src/
+./core/*


### PR DESCRIPTION
This PR:
- fix the position of `is_force_push_pr`
- make the title of PR conventional commits complaint
- add custom pat to allow to push updates to workflow files, otherwise not allowed (see [doc](https://github.com/AndreasAugustin/actions-template-sync#troubleshooting))
- ensure all content of `core` is excluded 